### PR TITLE
feat: add onchain custom decimals support #112

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,3 +9,10 @@ export const makeElipsisAddress = (address?: string | null, padding?: number): s
 export function checkImageURL(url: string) {
   return url.match(/\.(jpeg|jpg|gif|png|svg)$/) != null;
 }
+
+export function checkDecimals(value: string) {
+  if (value.includes(".")) return false;
+
+  const num = parseInt(value);
+  return num >= 0 && num <= 255;
+}

--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -34,6 +34,7 @@ export interface JettonDeployParams {
     symbol: string;
     description?: string;
     image?: string;
+    decimals?: string;
   };
   offchainUri?: string;
   owner: Address;

--- a/src/lib/jetton-minter.ts
+++ b/src/lib/jetton-minter.ts
@@ -22,7 +22,13 @@ enum OPS {
   Burn = 0x595f07bc,
 }
 
-export type JettonMetaDataKeys = "name" | "description" | "image" | "symbol" | "image_data";
+export type JettonMetaDataKeys =
+  | "name"
+  | "description"
+  | "image"
+  | "symbol"
+  | "image_data"
+  | "decimals";
 
 const jettonOnChainMetadataSpec: {
   [key in JettonMetaDataKeys]: "utf8" | "ascii" | undefined;
@@ -30,6 +36,7 @@ const jettonOnChainMetadataSpec: {
   name: "utf8",
   description: "utf8",
   image: "ascii",
+  decimals: "utf8",
   symbol: "utf8",
   image_data: undefined,
 };

--- a/src/pages/deployer/data.ts
+++ b/src/pages/deployer/data.ts
@@ -1,4 +1,4 @@
-import { checkImageURL } from "helpers";
+import { checkImageURL, checkDecimals } from "helpers";
 
 const onchainFormSpec = [
   {
@@ -24,9 +24,11 @@ const onchainFormSpec = [
     label: "Jetton decimals",
     description: "The decimal precision of your token (9 is TON default)",
     type: "number",
-    disabled: true,
+    disabled: false,
+    validate: checkDecimals,
     default: 9,
-    required: false,
+    required: true,
+    errorMessage: "Decimals amount from 0 to 255 is required", // https://github.com/ton-blockchain/TEPs/blob/master/text/0064-token-data-standard.md#jetton-metadata-attributes
   },
   {
     name: "mintAmount",

--- a/src/pages/deployer/index.tsx
+++ b/src/pages/deployer/index.tsx
@@ -51,6 +51,7 @@ function DeployerPage() {
         symbol: data.symbol,
         image: data.tokenImage,
         description: data.description,
+        decimals: data.decimals,
       },
       offchainUri: data.offchainUri,
       amountToMint: toNano(data.mintAmount),

--- a/src/pages/jetton/actions/UpdateMetadata.tsx
+++ b/src/pages/jetton/actions/UpdateMetadata.tsx
@@ -12,7 +12,8 @@ import { jettonDeployController } from "lib/deploy-controller";
 import WalletConnection from "services/wallet-connection";
 import { Address } from "ton";
 import useNotification from "hooks/useNotification";
-const inputsName = ["name", "symbol", "tokenImage", "description"];
+
+const inputsName = ["name", "symbol", "decimals", "tokenImage", "description"];
 
 const getInputs = () => {
   return onchainFormSpec.filter((specInput) => {

--- a/src/pages/jetton/index.tsx
+++ b/src/pages/jetton/index.tsx
@@ -5,7 +5,7 @@ import {
   balanceActions,
   getAdminMessage,
   getFaultyMetadataWarning,
-  getSymbolWarning,
+  getMetadataWarning,
   getTotalSupplyWarning,
   totalSupplyActions,
 } from "./util";
@@ -37,6 +37,7 @@ function JettonPage() {
     adminRevokedOwnership,
     balance,
     symbol,
+    decimals,
     name,
     description,
     jettonMaster,
@@ -110,7 +111,7 @@ function JettonPage() {
                 title="Symbol"
                 value={symbol}
                 dataLoading={jettonLoading}
-                message={getSymbolWarning(persistenceType, adminRevokedOwnership)}
+                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
               />
               <Row
                 title="Total Supply"
@@ -124,6 +125,12 @@ function JettonPage() {
                 dataLoading={jettonLoading}
                 message={getTotalSupplyWarning(persistenceType, adminRevokedOwnership)}
                 actions={totalSupplyActions}
+              />
+              <Row
+                title="Decimals"
+                value={decimals}
+                dataLoading={jettonLoading}
+                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
               />
               <UpdateMetadata />
             </StyledCategoryFields>

--- a/src/pages/jetton/util.ts
+++ b/src/pages/jetton/util.ts
@@ -54,7 +54,7 @@ export const getAdminMessage = (
   };
 };
 
-export const getSymbolWarning = (
+export const getMetadataWarning = (
   persistenceType?: persistenceType,
   adminRevokedOwnership?: boolean,
 ): JettonDetailMessage | undefined => {
@@ -68,7 +68,7 @@ export const getSymbolWarning = (
     case "offchain_ipfs":
       return {
         type: "warning",
-        text: `This jetton’s metadata (name and symbol) is stored on IPFS instead of on-chain. It will not change, but be careful, it can disappear and become unpinned. [Read more](${offChainGithubUrl})`,
+        text: `This jetton’s metadata (name, decimals and symbol) is stored on IPFS instead of on-chain. It will not change, but be careful, it can disappear and become unpinned. [Read more](${offChainGithubUrl})`,
       };
     case "offchain_private_domain":
       return {

--- a/src/store/jetton-store/index.ts
+++ b/src/store/jetton-store/index.ts
@@ -5,6 +5,7 @@ export interface JettonStoreState {
   isAdmin: boolean;
   adminRevokedOwnership: boolean;
   symbol?: string;
+  decimals?: string;
   name?: string;
   jettonImage?: string;
   description?: string;
@@ -28,6 +29,7 @@ const jettonStateAtom = atom<JettonStoreState>({
     isAdmin: false,
     adminRevokedOwnership: true,
     symbol: undefined,
+    decimals: undefined,
     name: undefined,
     jettonImage: undefined,
     description: undefined,

--- a/src/store/jetton-store/useJettonStore.ts
+++ b/src/store/jetton-store/useJettonStore.ts
@@ -112,6 +112,7 @@ function useJettonStore() {
           totalSupply: fromNano(result.minter.totalSupply),
           name: result.minter.metadata.name,
           symbol: result.minter.metadata.symbol,
+          decimals: result.minter.metadata.decimals,
           adminRevokedOwnership: _adminAddress === zeroAddress().toFriendly(),
           isAdmin: admin,
           adminAddress: _adminAddress,


### PR DESCRIPTION
Solves #112 

This PR adds ability to set custom decimals onchain value. [Here](https://testnet.tonapi.io/account/kQAdeaoRSNRoV7ABKgr-gx70pSG6XTTPyITnGLTUZNevSTsE/jetton/ttt) one may find an example of a deployed jetton contract with `decimals: 3`

- Extends onchain deployer page with an ability to set custom decimals field
- Shows decimals info on `/jetton` page
- Allows admin to update an existing jetton metadata including decimals 

I am not sure about description text and `require` property. Probably a better option would be is to keep decimals field optional with default 9 value.
