### PR TITLE
support dynamic decimals on all operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^16.11.36",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",
+        "bignumber.js": "^9.1.0",
         "buffer": "^6.0.3",
         "notistack": "^2.0.5",
         "prettier": "^2.7.1",
@@ -5967,6 +5968,14 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
       "engines": {
         "node": "*"
       }
@@ -24781,6 +24790,11 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "bignumber.js": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^16.11.36",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
+    "bignumber.js": "^9.1.0",
     "buffer": "^6.0.3",
     "notistack": "^2.0.5",
     "prettier": "^2.7.1",

--- a/src/components/BigNumberDisplay.tsx
+++ b/src/components/BigNumberDisplay.tsx
@@ -1,11 +1,17 @@
-import React from "react";
+import BN from "bn.js";
 import NumberFormat from "react-number-format";
+import BigNumber from "bignumber.js";
+import { fromDecimals } from "utils";
 
 interface Props {
-  value: string | number;
+  value: BigNumber | BN | number | string;
+  decimals?: number | string;
 }
-function BigNumberDisplay({ value }: Props) {
-  return <NumberFormat displayType="text" value={value} thousandSeparator={true} />;
+function BigNumberDisplay({ value, decimals }: Props) {
+  if (decimals) {
+    value = fromDecimals(value.toString(), decimals);
+  }
+  return <NumberFormat displayType="text" value={value.toString()} thousandSeparator={true} />;
 }
 
 export default BigNumberDisplay;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -9,3 +9,10 @@ export const makeElipsisAddress = (address?: string | null, padding?: number): s
 export function checkImageURL(url: string) {
   return url.match(/\.(jpeg|jpg|gif|png|svg)$/) != null;
 }
+
+export function checkDecimals(value: string) {
+  if (value.includes(".")) return false;
+
+  const num = parseInt(value);
+  return num >= 0 && num <= 255;
+}

--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -234,7 +234,6 @@ class JettonDeployController {
         source: Address.parse(address),
       }),
     );
-
     await connection.requestTransaction({
       to: contractAddress,
       message: updateMetadataBody(buildJettonOnchainMetadata(data)),

--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -34,7 +34,7 @@ export interface JettonDeployParams {
     symbol: string;
     description?: string;
     image?: string;
-    decimals: string;
+    decimals?: string;
   };
   offchainUri?: string;
   owner: Address;

--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -34,6 +34,7 @@ export interface JettonDeployParams {
     symbol: string;
     description?: string;
     image?: string;
+    decimals: string;
   };
   offchainUri?: string;
   owner: Address;
@@ -182,7 +183,7 @@ class JettonDeployController {
         "get_wallet_data",
         [],
         ([amount, _, jettonMasterAddressCell]) => ({
-          balance: (amount as unknown as BN).toString(),
+          balance: amount as unknown as BN,
           jWalletAddress,
           jettonMasterAddress: cellToAddress(jettonMasterAddressCell),
         }),

--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -234,6 +234,7 @@ class JettonDeployController {
         source: Address.parse(address),
       }),
     );
+
     await connection.requestTransaction({
       to: contractAddress,
       message: updateMetadataBody(buildJettonOnchainMetadata(data)),

--- a/src/lib/jetton-minter.ts
+++ b/src/lib/jetton-minter.ts
@@ -22,7 +22,13 @@ enum OPS {
   Burn = 0x595f07bc,
 }
 
-export type JettonMetaDataKeys = "name" | "description" | "image" | "symbol" | "image_data";
+export type JettonMetaDataKeys =
+  | "name"
+  | "description"
+  | "image"
+  | "symbol"
+  | "image_data"
+  | "decimals";
 
 const jettonOnChainMetadataSpec: {
   [key in JettonMetaDataKeys]: "utf8" | "ascii" | undefined;
@@ -32,6 +38,7 @@ const jettonOnChainMetadataSpec: {
   image: "ascii",
   symbol: "utf8",
   image_data: undefined,
+  decimals: "utf8",
 };
 
 const sha256 = (str: string) => {

--- a/src/lib/jetton-minter.ts
+++ b/src/lib/jetton-minter.ts
@@ -39,7 +39,6 @@ const jettonOnChainMetadataSpec: {
   decimals: "utf8",
   symbol: "utf8",
   image_data: undefined,
-  decimals: "utf8",
 };
 
 const sha256 = (str: string) => {

--- a/src/lib/jetton-minter.ts
+++ b/src/lib/jetton-minter.ts
@@ -36,6 +36,7 @@ const jettonOnChainMetadataSpec: {
   name: "utf8",
   description: "utf8",
   image: "ascii",
+  decimals: "utf8",
   symbol: "utf8",
   image_data: undefined,
   decimals: "utf8",

--- a/src/pages/deployer/data.ts
+++ b/src/pages/deployer/data.ts
@@ -1,4 +1,4 @@
-import { checkImageURL } from "helpers";
+import { checkImageURL, checkDecimals } from "helpers";
 
 const onchainFormSpec = [
   {
@@ -25,8 +25,10 @@ const onchainFormSpec = [
     description: "The decimal precision of your token (9 is TON default)",
     type: "number",
     disabled: false,
+    validate: checkDecimals,
     default: 9,
-    required: false,
+    required: true,
+    errorMessage: "Decimals amount from 0 to 255 is required", // https://github.com/ton-blockchain/TEPs/blob/master/text/0064-token-data-standard.md#jetton-metadata-attributes
   },
   {
     name: "mintAmount",

--- a/src/pages/deployer/data.ts
+++ b/src/pages/deployer/data.ts
@@ -24,7 +24,6 @@ const onchainFormSpec = [
     label: "Jetton decimals",
     description: "The decimal precision of your token (9 is TON default)",
     type: "number",
-    disabled: false,
     validate: checkDecimals,
     default: 9,
     required: true,

--- a/src/pages/deployer/data.ts
+++ b/src/pages/deployer/data.ts
@@ -24,7 +24,7 @@ const onchainFormSpec = [
     label: "Jetton decimals",
     description: "The decimal precision of your token (9 is TON default)",
     type: "number",
-    disabled: true,
+    disabled: false,
     default: 9,
     required: false,
   },

--- a/src/pages/deployer/index.tsx
+++ b/src/pages/deployer/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Address, toNano } from "ton";
+import { Address } from "ton";
 import useConnectionStore from "store/connection-store/useConnectionStore";
 import { Fade, Link, Typography } from "@mui/material";
 import { jettonDeployController } from "lib/deploy-controller";
@@ -23,10 +23,9 @@ import SearchInput from "./SearchInput";
 import SectionLabel from "components/SectionLabel";
 import analytics, { AnalyticsAction, AnalyticsCategory } from "services/analytics";
 import { JettonDeployParams } from "../../lib/deploy-controller";
-import { getUrlParam, toDecimals } from "utils";
+import { getUrlParam, toDecimalsBN } from "utils";
 import { offchainFormSpec, onchainFormSpec } from "./data";
 import Form from "components/Form";
-import BN from "bn.js";
 const DEFAULT_DECIMALS = 9;
 
 const isOffchainInternal = getUrlParam("offchainINTERNAL") !== null;
@@ -70,7 +69,7 @@ function DeployerPage() {
         decimals: decimals,
       },
       offchainUri: data.offchainUri,
-      amountToMint: new BN(toDecimals(data.mintAmount, decimals || DEFAULT_DECIMALS)),
+      amountToMint: toDecimalsBN(data.mintAmount, decimals ?? DEFAULT_DECIMALS),
     };
     setIsLoading(true);
     const deployParams = createDeployParams(params, data.offchainUri);

--- a/src/pages/deployer/index.tsx
+++ b/src/pages/deployer/index.tsx
@@ -54,7 +54,9 @@ function DeployerPage() {
 
     let decimals = data.decimals;
     if (data.offchainUri) {
-      let res = await fetchDecimalsOffchain(data.offchainUri);
+      let res = await fetchDecimalsOffchain(
+        data.offchainUri.replace("ipfs://", "https://ipfs.io/ipfs/"),
+      );
       decimals = res.decimals;
     }
 
@@ -65,10 +67,10 @@ function DeployerPage() {
         symbol: data.symbol,
         image: data.tokenImage,
         description: data.description,
-        decimals: data.decimals,
+        decimals: decimals,
       },
       offchainUri: data.offchainUri,
-      amountToMint: new BN(toDecimals(data.mintAmount, data.decimals || DEFAULT_DECIMALS)),
+      amountToMint: new BN(toDecimals(data.mintAmount, decimals || DEFAULT_DECIMALS)),
     };
     setIsLoading(true);
     const deployParams = createDeployParams(params, data.offchainUri);

--- a/src/pages/deployer/index.tsx
+++ b/src/pages/deployer/index.tsx
@@ -24,9 +24,10 @@ import SearchInput from "./SearchInput";
 import SectionLabel from "components/SectionLabel";
 import analytics, { AnalyticsAction, AnalyticsCategory } from "services/analytics";
 import { JettonDeployParams } from "../../lib/deploy-controller";
-import { getUrlParam } from "utils";
+import { getUrlParam, toDecimals } from "utils";
 import { offchainFormSpec, onchainFormSpec } from "./data";
 import Form from "components/Form";
+import BN from "bn.js";
 
 const isOffchainInternal = getUrlParam("offchainINTERNAL") !== null;
 
@@ -51,9 +52,10 @@ function DeployerPage() {
         symbol: data.symbol,
         image: data.tokenImage,
         description: data.description,
+        decimals: data.decimals,
       },
       offchainUri: data.offchainUri,
-      amountToMint: toNano(data.mintAmount),
+      amountToMint: new BN(toDecimals(data.mintAmount, data.decimals)),
     };
     setIsLoading(true);
     const deployParams = createDeployParams(params, data.offchainUri);

--- a/src/pages/jetton/actions/BurnJettonsAction.tsx
+++ b/src/pages/jetton/actions/BurnJettonsAction.tsx
@@ -10,13 +10,13 @@ import { jettonDeployController } from "lib/deploy-controller";
 import { useState } from "react";
 import WalletConnection from "services/wallet-connection";
 import useJettonStore from "store/jetton-store/useJettonStore";
-import { toNano } from "ton";
+import { toDecimalsBN } from "utils";
 
 function BurnJettonsAction() {
   const [amount, setAmount] = useState<number | undefined>(undefined);
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const { jettonMaster, symbol, getJettonDetails, balance, jettonAddress, isMyWallet } =
+  const { jettonMaster, symbol, getJettonDetails, balance, jettonAddress, isMyWallet, decimals } =
     useJettonStore();
   const { showNotification } = useNotification();
 
@@ -34,9 +34,10 @@ function BurnJettonsAction() {
       return;
     }
 
-    const value = toNano(amount);
+    const valueDecimals = toDecimalsBN(amount, decimals);
+    const balanceDecimals = toDecimalsBN(balance!!.toString(), decimals);
 
-    if (value.gt(toNano(balance!!))) {
+    if (valueDecimals.gt(balanceDecimals)) {
       const msg = (
         <>
           Maximum amount to burn is <BigNumberDisplay value={balance} />
@@ -49,7 +50,7 @@ function BurnJettonsAction() {
     try {
       setIsLoading(true);
       const connection = WalletConnection.getConnection();
-      await jettonDeployController.burnJettons(connection, value, jettonAddress!);
+      await jettonDeployController.burnJettons(connection, valueDecimals, jettonAddress!);
       setOpen(false);
       const message = `Successfully burned ${amount.toLocaleString()} ${symbol}`;
       showNotification(message, "success");

--- a/src/pages/jetton/actions/BurnJettonsAction.tsx
+++ b/src/pages/jetton/actions/BurnJettonsAction.tsx
@@ -34,8 +34,8 @@ function BurnJettonsAction() {
       return;
     }
 
-    const valueDecimals = toDecimalsBN(amount, decimals);
-    const balanceDecimals = toDecimalsBN(balance!!.toString(), decimals);
+    const valueDecimals = toDecimalsBN(amount, decimals!);
+    const balanceDecimals = toDecimalsBN(balance!!.toString(), decimals!);
 
     if (valueDecimals.gt(balanceDecimals)) {
       const msg = (

--- a/src/pages/jetton/actions/MintJettonsAction.tsx
+++ b/src/pages/jetton/actions/MintJettonsAction.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import WalletConnection from "services/wallet-connection";
 import useJettonStore from "store/jetton-store/useJettonStore";
 import { Address } from "ton";
-import { fromDecimals, toDecimals } from "utils";
+import { toDecimalsBN } from "utils";
 
 function MintJettonsAction() {
   const [amount, setAmount] = useState<number | undefined>(undefined);
@@ -34,16 +34,12 @@ function MintJettonsAction() {
       showNotification(`Minimum amount of ${symbol} to mint is 1`, "warning");
       return;
     }
-    const value = toDecimals(amount, decimals!);
+    const value = toDecimalsBN(amount, decimals!);
 
     try {
       setIsLoading(true);
       const connection = WalletConnection.getConnection();
-      await jettonDeployController.mint(
-        connection,
-        Address.parse(jettonMaster),
-        new BN(value.toString()),
-      );
+      await jettonDeployController.mint(connection, Address.parse(jettonMaster), value);
       setOpen(false);
       const message = (
         <>

--- a/src/pages/jetton/actions/MintJettonsAction.tsx
+++ b/src/pages/jetton/actions/MintJettonsAction.tsx
@@ -47,7 +47,7 @@ function MintJettonsAction() {
       setOpen(false);
       const message = (
         <>
-          Successfully minted <BigNumberDisplay value={amount} decimals={decimals} /> {symbol}
+          Successfully minted <BigNumberDisplay value={amount} /> {symbol}
         </>
       );
       getJettonDetails();

--- a/src/pages/jetton/actions/MintJettonsAction.tsx
+++ b/src/pages/jetton/actions/MintJettonsAction.tsx
@@ -34,7 +34,7 @@ function MintJettonsAction() {
       showNotification(`Minimum amount of ${symbol} to mint is 1`, "warning");
       return;
     }
-    const value = toDecimals(amount, decimals);
+    const value = toDecimals(amount, decimals!);
 
     try {
       setIsLoading(true);

--- a/src/pages/jetton/actions/TransferAction.tsx
+++ b/src/pages/jetton/actions/TransferAction.tsx
@@ -11,7 +11,7 @@ import WalletConnection from "services/wallet-connection";
 import useConnectionStore from "store/connection-store/useConnectionStore";
 import useJettonStore from "store/jetton-store/useJettonStore";
 import { StyledInput } from "styles/styles";
-import { isValidAddress, toDecimals, toDecimalsBN } from "utils";
+import { isValidAddress, toDecimalsBN } from "utils";
 import { StyledSectionTitle } from "../Row";
 
 const getError = (
@@ -68,7 +68,7 @@ function TransferAction() {
       const connection = WalletConnection.getConnection();
       await jettonDeployController.transfer(
         connection,
-        new BN(toDecimals(amount!.toString(), decimals!)),
+        toDecimalsBN(amount!.toString(), decimals!),
         toAddress!,
         connectedWalletAddress!,
         jettonAddress,

--- a/src/pages/jetton/actions/TransferAction.tsx
+++ b/src/pages/jetton/actions/TransferAction.tsx
@@ -57,7 +57,7 @@ function TransferAction() {
   }
 
   const onSubmit = async () => {
-    const error = getError(toAddress, toDecimalsBN(amount!, decimals), balance, symbol, decimals);
+    const error = getError(toAddress, toDecimalsBN(amount!, decimals!), balance, symbol, decimals);
     if (error) {
       showNotification(error, "warning", undefined, 3000);
       return;
@@ -68,7 +68,7 @@ function TransferAction() {
       const connection = WalletConnection.getConnection();
       await jettonDeployController.transfer(
         connection,
-        new BN(toDecimals(amount!.toString(), decimals)),
+        new BN(toDecimals(amount!.toString(), decimals!)),
         toAddress!,
         connectedWalletAddress!,
         jettonAddress,

--- a/src/pages/jetton/actions/UpdateMetadata.tsx
+++ b/src/pages/jetton/actions/UpdateMetadata.tsx
@@ -12,7 +12,8 @@ import { jettonDeployController } from "lib/deploy-controller";
 import WalletConnection from "services/wallet-connection";
 import { Address } from "ton";
 import useNotification from "hooks/useNotification";
-const inputsName = ["name", "symbol", "tokenImage", "description"];
+
+const inputsName = ["name", "symbol", "decimals", "tokenImage", "description"];
 
 const getInputs = () => {
   return onchainFormSpec.filter((specInput) => {

--- a/src/pages/jetton/actions/UpdateMetadata.tsx
+++ b/src/pages/jetton/actions/UpdateMetadata.tsx
@@ -60,6 +60,7 @@ function UpdateMetadata() {
           name: values.name,
           description: values.description,
           image: values.tokenImage,
+          decimals: values.decimals,
         },
         WalletConnection.getConnection(),
       );

--- a/src/pages/jetton/actions/UpdateMetadata.tsx
+++ b/src/pages/jetton/actions/UpdateMetadata.tsx
@@ -16,9 +16,16 @@ import useNotification from "hooks/useNotification";
 const inputsName = ["name", "symbol", "decimals", "tokenImage", "description"];
 
 const getInputs = () => {
-  return onchainFormSpec.filter((specInput) => {
-    return inputsName.includes(specInput.name);
-  });
+  return onchainFormSpec
+    .filter((specInput) => {
+      return inputsName.includes(specInput.name);
+    })
+    .map((specInput) => {
+      return {
+        ...specInput,
+        disabled: specInput.name === "decimals" ? true : undefined,
+      };
+    });
 };
 
 const createDefaults = (state: JettonStoreState) => {

--- a/src/pages/jetton/index.tsx
+++ b/src/pages/jetton/index.tsx
@@ -37,7 +37,6 @@ function JettonPage() {
     adminRevokedOwnership,
     balance,
     symbol,
-    decimals,
     name,
     decimals,
     description,

--- a/src/pages/jetton/index.tsx
+++ b/src/pages/jetton/index.tsx
@@ -5,7 +5,7 @@ import {
   balanceActions,
   getAdminMessage,
   getFaultyMetadataWarning,
-  getSymbolWarning,
+  getMetadataWarning,
   getTotalSupplyWarning,
   totalSupplyActions,
 } from "./util";
@@ -37,6 +37,7 @@ function JettonPage() {
     adminRevokedOwnership,
     balance,
     symbol,
+    decimals,
     name,
     decimals,
     description,
@@ -111,7 +112,7 @@ function JettonPage() {
                 title="Symbol"
                 value={symbol}
                 dataLoading={jettonLoading}
-                message={getSymbolWarning(persistenceType, adminRevokedOwnership)}
+                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
               />
               <Row
                 title="Decimals"
@@ -135,6 +136,12 @@ function JettonPage() {
                 dataLoading={jettonLoading}
                 message={getTotalSupplyWarning(persistenceType, adminRevokedOwnership)}
                 actions={totalSupplyActions}
+              />
+              <Row
+                title="Decimals"
+                value={decimals}
+                dataLoading={jettonLoading}
+                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
               />
               <UpdateMetadata />
             </StyledCategoryFields>

--- a/src/pages/jetton/index.tsx
+++ b/src/pages/jetton/index.tsx
@@ -38,6 +38,7 @@ function JettonPage() {
     balance,
     symbol,
     name,
+    decimals,
     description,
     jettonMaster,
     persistenceType,
@@ -113,11 +114,21 @@ function JettonPage() {
                 message={getSymbolWarning(persistenceType, adminRevokedOwnership)}
               />
               <Row
+                title="Decimals"
+                value={decimals}
+                dataLoading={jettonLoading}
+                message={getSymbolWarning(persistenceType, adminRevokedOwnership)}
+              />
+              <Row
                 title="Total Supply"
                 value={
                   totalSupply && (
                     <>
-                      <BigNumberDisplay value={totalSupply} /> {symbol}
+                      <BigNumberDisplay
+                        value={totalSupply.toString()}
+                        decimals={parseInt(decimals)}
+                      />{" "}
+                      {symbol}
                     </>
                   )
                 }
@@ -144,7 +155,7 @@ function JettonPage() {
                 value={
                   balance && (
                     <>
-                      <BigNumberDisplay value={balance} /> {symbol}
+                      <BigNumberDisplay value={balance} decimals={decimals} /> {symbol}
                     </>
                   )
                 }

--- a/src/pages/jetton/index.tsx
+++ b/src/pages/jetton/index.tsx
@@ -117,7 +117,7 @@ function JettonPage() {
                 title="Decimals"
                 value={decimals}
                 dataLoading={jettonLoading}
-                message={getSymbolWarning(persistenceType, adminRevokedOwnership)}
+                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
               />
               <Row
                 title="Total Supply"
@@ -126,7 +126,7 @@ function JettonPage() {
                     <>
                       <BigNumberDisplay
                         value={totalSupply.toString()}
-                        decimals={parseInt(decimals)}
+                        decimals={parseInt(decimals!)}
                       />{" "}
                       {symbol}
                     </>
@@ -136,12 +136,7 @@ function JettonPage() {
                 message={getTotalSupplyWarning(persistenceType, adminRevokedOwnership)}
                 actions={totalSupplyActions}
               />
-              <Row
-                title="Decimals"
-                value={decimals}
-                dataLoading={jettonLoading}
-                message={getMetadataWarning(persistenceType, adminRevokedOwnership)}
-              />
+
               <UpdateMetadata />
             </StyledCategoryFields>
           </StyledRead>

--- a/src/pages/jetton/util.ts
+++ b/src/pages/jetton/util.ts
@@ -4,6 +4,7 @@ import ConnectAction from "./actions/ConnectAction";
 import MintJettonsAction from "./actions/MintJettonsAction";
 import RevokeOwnershipAction from "./actions/RevokeOwnershipAction";
 import { JettonDetailMessage } from "./types";
+export { BigNumber } from "bignumber.js";
 
 const commonGithubUrl =
   "https://github.com/ton-defi-org/jetton-deployer-contracts#protect-yourself-and-your-users";

--- a/src/pages/jetton/util.ts
+++ b/src/pages/jetton/util.ts
@@ -55,7 +55,7 @@ export const getAdminMessage = (
   };
 };
 
-export const getSymbolWarning = (
+export const getMetadataWarning = (
   persistenceType?: persistenceType,
   adminRevokedOwnership?: boolean,
 ): JettonDetailMessage | undefined => {
@@ -69,7 +69,7 @@ export const getSymbolWarning = (
     case "offchain_ipfs":
       return {
         type: "warning",
-        text: `This jetton’s metadata (name and symbol) is stored on IPFS instead of on-chain. It will not change, but be careful, it can disappear and become unpinned. [Read more](${offChainGithubUrl})`,
+        text: `This jetton’s metadata (name, decimals and symbol) is stored on IPFS instead of on-chain. It will not change, but be careful, it can disappear and become unpinned. [Read more](${offChainGithubUrl})`,
       };
     case "offchain_private_domain":
       return {

--- a/src/store/jetton-store/index.ts
+++ b/src/store/jetton-store/index.ts
@@ -6,6 +6,7 @@ export interface JettonStoreState {
   isAdmin: boolean;
   adminRevokedOwnership: boolean;
   symbol?: string;
+  decimals?: string;
   name?: string;
   jettonImage?: string;
   description?: string;
@@ -30,6 +31,7 @@ const jettonStateAtom = atom<JettonStoreState>({
     isAdmin: false,
     adminRevokedOwnership: true,
     symbol: undefined,
+    decimals: undefined,
     name: undefined,
     jettonImage: undefined,
     description: undefined,

--- a/src/store/jetton-store/index.ts
+++ b/src/store/jetton-store/index.ts
@@ -1,3 +1,4 @@
+import BN from "bn.js";
 import { persistenceType } from "lib/jetton-minter";
 import { atom } from "recoil";
 
@@ -9,10 +10,11 @@ export interface JettonStoreState {
   jettonImage?: string;
   description?: string;
   adminAddress?: string;
-  balance?: string;
+  balance?: BN;
   jettonMaster?: string;
   persistenceType?: persistenceType;
-  totalSupply?: string;
+  totalSupply?: BN;
+  decimals: string;
   jettonAddress?: string;
   isJettonDeployerFaultyOnChainData?: boolean;
   jettonLoading: boolean;
@@ -33,6 +35,7 @@ const jettonStateAtom = atom<JettonStoreState>({
     description: undefined,
     adminAddress: undefined,
     balance: undefined,
+    decimals: "9",
     jettonMaster: undefined,
     totalSupply: undefined,
     jettonAddress: undefined,

--- a/src/store/jetton-store/index.ts
+++ b/src/store/jetton-store/index.ts
@@ -15,7 +15,6 @@ export interface JettonStoreState {
   jettonMaster?: string;
   persistenceType?: persistenceType;
   totalSupply?: BN;
-  decimals: string;
   jettonAddress?: string;
   isJettonDeployerFaultyOnChainData?: boolean;
   jettonLoading: boolean;
@@ -31,13 +30,12 @@ const jettonStateAtom = atom<JettonStoreState>({
     isAdmin: false,
     adminRevokedOwnership: true,
     symbol: undefined,
-    decimals: undefined,
+    decimals: "9",
     name: undefined,
     jettonImage: undefined,
     description: undefined,
     adminAddress: undefined,
     balance: undefined,
-    decimals: "9",
     jettonMaster: undefined,
     totalSupply: undefined,
     jettonAddress: undefined,

--- a/src/store/jetton-store/useJettonStore.ts
+++ b/src/store/jetton-store/useJettonStore.ts
@@ -4,7 +4,7 @@ import { EnvProfiles, Environments } from "lib/env-profiles";
 import { zeroAddress } from "lib/utils";
 import { useRecoilState, useResetRecoilState } from "recoil";
 import WalletConnection from "services/wallet-connection";
-import { Address, fromNano } from "ton";
+import { Address } from "ton";
 import { jettonStateAtom } from ".";
 import QuestiomMarkImg from "assets/question.png";
 import { useCallback } from "react";
@@ -12,6 +12,7 @@ import useNotification from "hooks/useNotification";
 import { useParams } from "react-router-dom";
 import useConnectionStore from "store/connection-store/useConnectionStore";
 import { getUrlParam, isValidAddress } from "utils";
+import { BN } from "bn.js";
 
 function useJettonStore() {
   const [state, setState] = useRecoilState(jettonStateAtom);
@@ -109,13 +110,14 @@ function useJettonStore() {
           persistenceType: result.minter.persistenceType,
           description: result.minter.metadata.description,
           jettonImage: image ?? QuestiomMarkImg,
-          totalSupply: fromNano(result.minter.totalSupply),
+          totalSupply: result.minter.totalSupply,
           name: result.minter.metadata.name,
           symbol: result.minter.metadata.symbol,
           adminRevokedOwnership: _adminAddress === zeroAddress().toFriendly(),
           isAdmin: admin,
+          decimals: result.minter.metadata.decimals || "9",
           adminAddress: _adminAddress,
-          balance: result.jettonWallet ? fromNano(result.jettonWallet.balance) : undefined,
+          balance: result.jettonWallet ? result.jettonWallet.balance : undefined,
           jettonAddress: result.jettonWallet?.jWalletAddress.toFriendly(),
           jettonMaster: id,
           isMyWallet,

--- a/src/store/jetton-store/useJettonStore.ts
+++ b/src/store/jetton-store/useJettonStore.ts
@@ -113,7 +113,6 @@ function useJettonStore() {
           totalSupply: result.minter.totalSupply,
           name: result.minter.metadata.name,
           symbol: result.minter.metadata.symbol,
-          decimals: result.minter.metadata.decimals,
           adminRevokedOwnership: _adminAddress === zeroAddress().toFriendly(),
           isAdmin: admin,
           decimals: result.minter.metadata.decimals || "9",

--- a/src/store/jetton-store/useJettonStore.ts
+++ b/src/store/jetton-store/useJettonStore.ts
@@ -113,6 +113,7 @@ function useJettonStore() {
           totalSupply: result.minter.totalSupply,
           name: result.minter.metadata.name,
           symbol: result.minter.metadata.symbol,
+          decimals: result.minter.metadata.decimals,
           adminRevokedOwnership: _adminAddress === zeroAddress().toFriendly(),
           isAdmin: admin,
           decimals: result.minter.metadata.decimals || "9",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+import BigNumber from "bignumber.js";
+import { BN } from "bn.js";
 import { zeroAddress } from "lib/utils";
 import { Address } from "ton";
 
@@ -25,3 +27,17 @@ export const isValidAddress = (address: string, errorText?: string) => {
     return false;
   }
 };
+
+const ten = new BigNumber(10);
+
+export function toDecimals(num: number | string, decimals: number | string) {
+  return BigNumber(num).multipliedBy(ten.pow(decimals)).toFixed();
+}
+
+export function toDecimalsBN(num: number | string, decimals: number | string) {
+  return new BN(BigNumber(num).multipliedBy(ten.pow(decimals)).toFixed());
+}
+
+export function fromDecimals(num: number | string, decimals: number | string) {
+  return BigNumber(num).div(ten.pow(decimals)).toFixed();
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,12 +30,8 @@ export const isValidAddress = (address: string, errorText?: string) => {
 
 const ten = new BigNumber(10);
 
-export function toDecimals(num: number | string, decimals: number | string) {
-  return BigNumber(num).multipliedBy(ten.pow(decimals)).toFixed();
-}
-
 export function toDecimalsBN(num: number | string, decimals: number | string) {
-  return new BN(BigNumber(num).multipliedBy(ten.pow(decimals)).toFixed());
+  return new BN(BigNumber(num).multipliedBy(ten.pow(decimals)).toFixed(0));
 }
 
 export function fromDecimals(num: number | string, decimals: number | string) {


### PR DESCRIPTION
- Added decimal view on jetton data panel ( right side)
- Added decimal input on the create jetton screen
- `<BigNumberDisplay />` accepts decimals as a parameter and renders a bignumber properly
- all `toNano` and `fromNano` removed from code
- all actions transfer, burn, mint are migrated to support decimals

Jetton with 18 decimals
EQClJ69rJahzbZw-7nMZrtDHpkSiuKCrXywdAIUtIGjfLTP5 
