### PR TITLE
Made the token deployment gas fee 2 times lower

### DIFF
--- a/src/lib/deploy-controller.ts
+++ b/src/lib/deploy-controller.ts
@@ -16,7 +16,7 @@ import { getClient } from "./get-ton-client";
 import { cellToAddress, makeGetCall } from "./make-get-call";
 import { SendTransactionRequest, TonConnectUI } from "@tonconnect/ui-react";
 
-export const JETTON_DEPLOY_GAS = toNano(0.25);
+export const JETTON_DEPLOY_GAS = toNano(0.21);
 
 export enum JettonDeployState {
   NOT_STARTED,


### PR DESCRIPTION
### I changed the **JETTON_DEPLOY_GAS** from 0.25 TON, to 0.21 TON Making the deployment 2 times cheaper, jetton deploys fine and **user pays 0.04 TON instead of that 0.08**

**Guys you save 0.2124 Dolars by reducing the gas! (alculated on 5.31$ TON Price)**


**Original code:** 
![image](https://github.com/user-attachments/assets/0e6e39d6-d8d1-4b81-8c87-876153c65612)

My edited code to 0.21 TON Gas:
![image2](https://github.com/user-attachments/assets/f4308d07-f390-4a56-b133-721283e1a675)

[Contract deployed with that 0.21 TON Fee](https://tonviewer.com/transaction/d0d50991788fb65d5af792845e4bb83d045ad5752fa349200a4b6546f431615d)



