### PR TITLE
Add GOVNO token to the verified list

### DIFF
--- a/tokens_govno.json
+++ b/tokens_govno.json
@@ -1,0 +1,10 @@
+{
+  "address": "UQDVpLsomSw2iDXbrw7lGUM-5D8PTIZSZ0sSaHJDsX8WKins",
+  "name": "GOVNO",
+  "symbol": "GVN",
+  "decimals": 3,
+  "verified": true,
+  "social": {},
+  "description": "Official Jetton for GOVNO on TON",
+  "image": ""
+}


### PR DESCRIPTION
This PR adds the GOVNO Jetton token to the verified token list.
The contract is verified via TON Verifier and follows the Jetton standard.